### PR TITLE
Address '-fsanitize=undefined' Warning about Passing a Null Source Pointer to memcpy in '_AresHostentToAddrInfo'

### DIFF
--- a/third_party/CFNetwork/repo/Host/CFHost.c
+++ b/third_party/CFNetwork/repo/Host/CFHost.c
@@ -1955,7 +1955,9 @@ _AresHostentToAddrInfo(const struct hostent *hostent, CFStreamError *error) {
         current->ai_socktype = SOCK_STREAM;
         current->ai_addrlen  = addr_size;
 
-        memcpy(current->ai_canonname, hostent->h_name, canonname_len);
+        if ((hostent->h_name != NULL) && (canonname_len > 0)) {
+            memcpy(current->ai_canonname, hostent->h_name, canonname_len);
+        }
 
         // Copy the actual address data from the current hostent
         // address to the addrinfo socket address.


### PR DESCRIPTION
This addresses #12 by wrapping the call to `memcpy` in `_AresHostentToAddrInfo` with a test against both `hostent->h_name` not being null and `canonname_len` being greater than zero.