### PR TITLE
Address the '-Wsizeof-pointer-memaccess' Warning in '_NetServiceCallBack'

### DIFF
--- a/third_party/CFNetwork/repo/Stream/CFSocketStream.c
+++ b/third_party/CFNetwork/repo/Stream/CFSocketStream.c
@@ -2100,7 +2100,7 @@ _NetServiceCallBack(CFNetServiceRef theService, CFStreamError* error, _CFSocketS
 	if (ctxt->_error.error) {
 		
 		/* Copy the error for notification. */
-		memmove(&ctxt->_error, error, sizeof(error));
+		memmove(&ctxt->_error, error, sizeof(error[0]));
 		
 		/* Grab the client streams for error notification. */
 		if (ctxt->_clientReadStream && __CFBitIsSet(ctxt->_flags, kFlagBitReadStreamOpened))


### PR DESCRIPTION
This addresses #16 by dereferencing the pointer type, in a manner consistent with other such calls elsewhere in the code, used for `sizeof` resulting in a structure- rather than a pointer-length `memmove` operation.