### PR TITLE
Address the '-Wpointer-to-int-cast' Warnings in '_SocketStreamCreateSocket_NoLock'

### DIFF
--- a/third_party/CFNetwork/repo/Stream/CFSocketStream.c
+++ b/third_party/CFNetwork/repo/Stream/CFSocketStream.c
@@ -3096,17 +3096,17 @@ _SocketStreamCreateSocket_NoLock(_CFSocketStreamContext* ctxt, CFDataRef address
 			
 			if (CFDictionaryContainsValue(info, _kCFStreamSocketFamily)) {
 				const void* tmp = CFDictionaryGetValue(info, _kCFStreamSocketFamily);
-				protocolFamily = (SInt32)tmp;
+				protocolFamily = (SInt32)((intptr_t)tmp);
 			}
 			
 			if (CFDictionaryContainsValue(info, _kCFStreamSocketType)) {
 				const void* tmp = CFDictionaryGetValue(info, _kCFStreamSocketType);
-				socketType = (SInt32)tmp;
+				socketType = (SInt32)((intptr_t)tmp);
 			}
 			
 			if (CFDictionaryContainsValue(info, _kCFStreamSocketProtocol)) {
 				const void* tmp = CFDictionaryGetValue(info, _kCFStreamSocketProtocol);
-				protocol = (SInt32)tmp;
+				protocol = (SInt32)((intptr_t)tmp);
 			}
 		}
 		


### PR DESCRIPTION
This addresses #17 by applying a two-step cast: first, casting the pointer to `intptr_t` (equivalent size, non-pointer type) and second, casting to the lvalue non-pointer type, `SInt32`.